### PR TITLE
chart "external-dns" version "5.5.2" not found in https://charts.bitn…

### DIFF
--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -63,7 +63,7 @@ resource "helm_release" "external_dns" {
     name = "external-dns"
     repository = "https://charts.bitnami.com/bitnami"
     chart = "external-dns"
-    version = "5.5.2"
+    version = "6.5.6"
     namespace = "kube-system"
     reuse_values = false
     reset_values = true


### PR DESCRIPTION
Our existing chart version no longer exists using the newest version works.
