### PR TITLE
JAR-5483

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -641,9 +641,12 @@ jarvice_scheduler: # N/A if jarvice.JARVICE_CLUSTER_TYPE: "downstream"
   # Set to "hard" to require pods to run on diff nodes.
   antiAffinity: "soft"
   resources:
-    limits:
+    requests:
       cpu: 1
       memory: 2Gi
+    limits:
+      cpu: 4
+      memory: 8Gi
   readinessProbe:
     initialDelaySeconds: 5
     periodSeconds: 30
@@ -683,8 +686,8 @@ jarvice_k8s_scheduler:
       cpu: 1
       memory: 2Gi
     limits:
-      cpu: 2
-      memory: 4Gi
+      cpu: 4
+      memory: 8Gi
   readinessProbe:
     initialDelaySeconds: 5
     periodSeconds: 30

--- a/values.yaml
+++ b/values.yaml
@@ -679,9 +679,12 @@ jarvice_k8s_scheduler:
   loadBalancerIP:
   ingressHost: # jarvice-k8s-scheduler.my-domain.com
   resources:
-    limits:
+    requests:
       cpu: 1
       memory: 2Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
   readinessProbe:
     initialDelaySeconds: 5
     periodSeconds: 30

--- a/values.yaml
+++ b/values.yaml
@@ -642,7 +642,7 @@ jarvice_scheduler: # N/A if jarvice.JARVICE_CLUSTER_TYPE: "downstream"
   antiAffinity: "soft"
   resources:
     requests:
-      cpu: 1
+      cpu: 2
       memory: 2Gi
     limits:
       cpu: 4

--- a/values.yaml
+++ b/values.yaml
@@ -719,11 +719,11 @@ jarvice_pod_scheduler:
   enabled: true
   resources:
     requests:
-      cpu: 1
+      cpu: 2
       memory: 2Gi
     limits:
-      cpu: 2
-      memory: 4Gi
+      cpu: 4
+      memory: 8Gi
   readinessProbe:
     initialDelaySeconds: 5
     periodSeconds: 30

--- a/values.yaml
+++ b/values.yaml
@@ -718,9 +718,12 @@ jarvice_k8s_scheduler:
 jarvice_pod_scheduler:
   enabled: true
   resources:
-    limits:
+    requests:
       cpu: 1
       memory: 2Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
   readinessProbe:
     initialDelaySeconds: 5
     periodSeconds: 30


### PR DESCRIPTION
burstable QoS adjustments for various scheduler components to avoid throttling by kubelet; also increase upstream scheduler baseline CPU requirements to take into account that it's running both regular scheduler and sched-pass (1 was not enough before).