### PR TITLE
remove newlines from ssh-keys

### DIFF
--- a/terraform/modules/common/locals.tf
+++ b/terraform/modules/common/locals.tf
@@ -40,7 +40,7 @@ EOF
 
 locals {
     ssh_public_key_file = lookup(var.cluster.meta, "ssh_public_key", null) != null ? lookup(var.cluster.meta, "ssh_public_key", null) : lookup(var.global.meta, "ssh_public_key", null)
-    ssh_public_key = local.ssh_public_key_file == null ? "" : fileexists(local.ssh_public_key_file) ? file(local.ssh_public_key_file) : ""
+    ssh_public_key = local.ssh_public_key_file == null ? "" : fileexists(local.ssh_public_key_file) ? trimspace(file(local.ssh_public_key_file)) : ""
 }
 
 locals {

--- a/terraform/modules/gke/main.tf
+++ b/terraform/modules/gke/main.tf
@@ -90,9 +90,7 @@ resource "google_container_cluster" "jarvice" {
 
         metadata = {
             disable-legacy-endpoints = "true"
-            ssh-keys = <<EOF
-${local.username}:${module.common.ssh_public_key}
-EOF
+            ssh-keys = "${local.username}:${module.common.ssh_public_key}"
         }
 
         #workload_metadata_config {
@@ -169,9 +167,7 @@ resource "google_container_node_pool" "jarvice_system" {
 
         metadata = {
             disable-legacy-endpoints = "true"
-            ssh-keys = <<EOF
-${local.username}:${module.common.ssh_public_key}
-EOF
+            ssh-keys = "${local.username}:${module.common.ssh_public_key}"
         }
 
         labels = {
@@ -225,9 +221,7 @@ resource "google_container_node_pool" "jarvice_dockerbuild" {
 
         metadata = {
             disable-legacy-endpoints = "true"
-            ssh-keys = <<EOF
-${local.username}:${module.common.ssh_public_key}
-EOF
+            ssh-keys = "${local.username}:${module.common.ssh_public_key}"
         }
 
         labels = {
@@ -286,9 +280,7 @@ resource "google_container_node_pool" "jarvice_images_pull" {
 
         metadata = {
             disable-legacy-endpoints = "true"
-            ssh-keys = <<EOF
-${local.username}:${module.common.ssh_public_key}
-EOF
+            ssh-keys = "${local.username}:${module.common.ssh_public_key}"
         }
 
         labels = {
@@ -367,9 +359,7 @@ resource "google_container_node_pool" "jarvice_compute" {
 
         metadata = {
             disable-legacy-endpoints = "true"
-            ssh-keys = <<EOF
-${local.username}:${module.common.ssh_public_key}
-EOF
+            ssh-keys = "${local.username}:${module.common.ssh_public_key}"
         }
 
         labels = merge(


### PR DESCRIPTION
update forces terraform to destroy existing k8s cluster