### PR TITLE
Fixing AWS ami image logic to avoid GPU image from being used for non…

### DIFF
--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -456,7 +456,7 @@ EOF
                 #create_launch_template = false
                 #launch_template_id = aws_launch_template.jarvice_compute[pool_name].id
                 instance_type = pool.nodes_type
-                ami_id = lookup(pool.meta, "ami_id", null) != null ? pool.meta.ami_id : lookup(var.cluster.meta, "arch", "") == "arm64" ? data.aws_ami.eks_arm64.id : lookup(pool.meta, "interface_type", null) == "efa" ? data.aws_ami.eks_amd64.id : data.aws_ami.eks_amd64_gpu.id
+                ami_id = lookup(pool.meta, "ami_id", null) != null ? pool.meta.ami_id : lookup(var.cluster.meta, "arch", "") == "arm64" ? data.aws_ami.eks_arm64.id : lookup(pool.meta, "gpu", false) ? data.aws_ami.eks_amd64_gpu.id : data.aws_ami.eks_amd64.id
                 desired_size = pool.nodes_num
                 min_size = pool.nodes_min
                 max_size = pool.nodes_max

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -737,6 +737,9 @@ eks = {  # Provision EKS infrastructure/clusters and deploy JARVICE
 
                     #Define custom ami_id for compute nodes. Leave commented out to pull in newest version of the AMI which will recreate pool.
                     #ami_id
+
+                    #Indicate whether the node pool should have a GPU capable AWS ami.
+                    #gpu = "true"
                 }
             },
             #jxecompute01 = {
@@ -752,6 +755,12 @@ eks = {  # Provision EKS infrastructure/clusters and deploy JARVICE
             #        # EFA requires k8s ver >= 1.19.  Supported instance types:
             #        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types (four p4d.24xlarge EFA interfaces not yet supported)
             #        #interface_type = "efa"
+            # 
+            #        #Define custom ami_id for compute nodes. Leave commented out to pull in newest version of the AMI which will recreate pool.
+            #        #ami_id
+
+            #        #Indicate whether the node pool should have a GPU capable AWS ami.
+            #        #gpu = "true"
             #    }
             #},
         }


### PR DESCRIPTION
Currently we select the GPU AMI for all but EFA instances. While this worked in the past the GPU ami now fails when no GPU is present. You can manually set AMI's but when changing k8s version it is not obvious which AMI to use unless you read the logic.