### PR TITLE
Traefik update

### DIFF
--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -102,7 +102,7 @@ resource "helm_release" "traefik" {
     name = "traefik"
     repository = "https://helm.traefik.io/traefik"
     chart = "traefik"
-    version = "10.7.1"
+    version = "21.2.1"
     namespace = "kube-system"
     reuse_values = false
     reset_values = true


### PR DESCRIPTION
Updated traefik helm chart. The new chart will not upgrade clean and needs the existing helm chart to be removed to allow for the new helm chart version to be installed. We will need to use the upgrade steps we have used previously deploying a secondary traefik and cuttting over to that instance during the upgrade.