### PR TITLE
Aws load balancer update

### DIFF
--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -12,7 +12,7 @@ resource "helm_release" "aws_load_balancer_controller" {
     name = "aws-load-balancer-controller"
     repository = "https://aws.github.io/eks-charts"
     chart = "aws-load-balancer-controller"
-    version = "1.3.2"
+    version = "1.4.7"
     namespace = "kube-system"
     reuse_values = false
     reset_values = true


### PR DESCRIPTION
Current version of the AWS load Balancer helm chart no longer works. 