### PR TITLE
Jar 8876: Select nimbix busybox image to prevent dockerhub ratelimiting

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1486,6 +1486,10 @@ keycloakx:
       subPath: jarvice_realm.json
   dbchecker:
     enabled: true
+    image: 
+      repository: us-docker.pkg.dev/jarvice/images/busybox
+      tag: latest
+      pullPolicy: IfNotPresent
   database:
     vendor: mariadb
     hostname: jarvice-db


### PR DESCRIPTION
As title describes, prevent ratelimiting for dbchecker.

Note: 1.32 doesn't exist, we have a latest tag thought which works.