### PR TITLE
Fix KNS template

### DIFF
--- a/templates/jarvice-kns-scheduler.yaml
+++ b/templates/jarvice-kns-scheduler.yaml
@@ -3,140 +3,108 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kns-sa-{{ .name }}
+  name: kns-sa
   namespace: jarvice-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kns-crb-{{ .name }}
+  name: kns-crb
 subjects:
 - kind: ServiceAccount
-  name: kns-sa-{{ .name }}
+  name: kns-sa
   namespace: jarvice-system
 roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 ---
-{{- if gt (.replicaCount | int) 1 }}
-{{- if (semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion) }}
+{{- if gt (.Values.jarvice_kns_scheduler.replicaCount | int) 1 }}
+{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:
-  name: jarvice-kns-scheduler-{{ .name }}
+  name: jarvice-kns-scheduler
 spec:
   selector:
     matchLabels:
-      deployment: jarvice-kns-scheduler-{{ .name }}
-{{- if (not (empty .pdb.minAvailable)) }}
-  minAvailable: {{ .pdb.minAvailable }}
-{{- else }}
-  minAvailable: {{ $.Values.jarvice_kns_scheduler.pdb.minAvailable }}
-{{- end }}
+      deployment: jarvice-kns-scheduler
+  minAvailable: {{ .Values.jarvice_kns_scheduler.pdb.minAvailable }}
 ---
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: jarvice-kns-scheduler-{{ .name }}
+  name: jarvice-kns-scheduler
   labels:
-    {{- include "jarvice.release_labels" $ | indent 4 }}
-    component: jarvice-kns-scheduler-{{ .name }}
-    deployment: jarvice-kns-scheduler-{{ .name }}
+    {{- include "jarvice.release_labels" . | indent 4 }}
+    component: jarvice-kns-scheduler
+    deployment: jarvice-kns-scheduler
     jarvice-system: core
 spec:
-{{- if (not (empty .replicaCount)) }}
-  replicas: {{ .replicaCount }}
-{{- else }}
-  replicas: {{ $.Values.jarvice_kns_scheduler.replicaCount }}
-{{- end }}
+  replicas: {{ .Values.jarvice_kns_scheduler.replicaCount }}
   selector:
     matchLabels:
-      deployment: jarvice-kns-scheduler-{{ .name }}
+      deployment: jarvice-kns-scheduler
   template:
     metadata:
       labels:
-        {{- include "jarvice.release_labels" $ | indent 8 }}
-        component: jarvice-kns-scheduler-{{ .name }}
-        deployment: jarvice-kns-scheduler-{{ .name }}
+        {{- include "jarvice.release_labels" . | indent 8 }}
+        component: jarvice-kns-scheduler
+        deployment: jarvice-kns-scheduler
         jarvice-system: core
       annotations:
         deployment-date: {{ now | quote }}
     spec:
-      serviceAccount: kns-sa-{{ .name }}
-      serviceAccountName: kns-sa-{{ .name }}
-{{- if (not (empty .tolerations)) }}
-      tolerations: {{ .tolerations }}
-{{- else if (not (empty $.Values.jarvice_kns_scheduler.tolerations)) }}
-      tolerations: {{ $.Values.jarvice_kns_scheduler.tolerations }}
-{{- else if (not (empty $.Values.jarvice.tolerations)) }}
-      tolerations: {{ $.Values.jarvice.tolerations }}
+      serviceAccount: kns-sa
+      serviceAccountName: kns-sa
+{{- if (not (empty .Values.jarvice_kns_scheduler.tolerations)) }}
+      tolerations: {{ .Values.jarvice_kns_scheduler.tolerations }}
+{{- else if (not (empty .Values.jarvice.tolerations)) }}
+      tolerations: {{ .Values.jarvice.tolerations }}
 {{- end }}
-{{- if (not (empty .nodeSelector)) }}
-      nodeSelector: {{ .nodeSelector }}
-{{- else if (not (empty $.Values.jarvice_kns_scheduler.nodeSelector)) }}
-      nodeSelector: {{ $.Values.jarvice_kns_scheduler.nodeSelector }}
-{{- else if (not (empty $.Values.jarvice.nodeSelector)) }}
-      nodeSelector: {{ $.Values.jarvice.nodeSelector }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.nodeSelector)) }}
+      nodeSelector: {{ .Values.jarvice_kns_scheduler.nodeSelector }}
+{{- else if (not (empty .Values.jarvice.nodeSelector)) }}
+      nodeSelector: {{ .Values.jarvice.nodeSelector }}
 {{- end }}
       affinity:
-{{- if (not (empty .nodeAffinity)) }}
-        nodeAffinity: {{ .nodeAffinity }}
-{{- else if (not (empty $.Values.jarvice_kns_scheduler.nodeAffinity)) }}
-        nodeAffinity: {{ $.Values.jarvice_kns_scheduler.nodeAffinity }}
-{{- else if (not (empty $.Values.jarvice.nodeAffinity)) }}
-        nodeAffinity: {{ $.Values.jarvice.nodeAffinity }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.nodeAffinity)) }}
+        nodeAffinity: {{ .Values.jarvice_kns_scheduler.nodeAffinity }}
+{{- else if (not (empty .Values.jarvice.nodeAffinity)) }}
+        nodeAffinity: {{ .Values.jarvice.nodeAffinity }}
 {{- end }}
         podAntiAffinity:
-{{- if (not (empty .antiAffinity)) }}
-        {{- if eq .antiAffinity "hard" }}
+        {{- if eq .Values.jarvice_kns_scheduler.antiAffinity "hard" }}
           requiredDuringSchedulingIgnoredDuringExecution:
           - topologyKey: "kubernetes.io/hostname"
             labelSelector:
               matchLabels:
-                deployment: jarvice-kns-scheduler-{{ .name }}
-        {{- else if eq .antiAffinity "soft" }}
+                deployment: jarvice-kns-scheduler
+        {{- else if eq .Values.jarvice_kns_scheduler.antiAffinity "soft" }}
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 5
             podAffinityTerm:
               topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
-                  deployment: jarvice-kns-scheduler-{{ .name }}
+                  deployment: jarvice-kns-scheduler
         {{- end }}
-{{- else }}
-        {{- if eq $.Values.jarvice_kns_scheduler.antiAffinity "hard" }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: "kubernetes.io/hostname"
-            labelSelector:
-              matchLabels:
-                deployment: jarvice-kns-scheduler-{{ .name }}
-        {{- else if eq $.Values.jarvice_kns_scheduler.antiAffinity "soft" }}
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 5
-            podAffinityTerm:
-              topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  deployment: jarvice-kns-scheduler-{{ .name }}
-        {{- end }}
-{{- end }}
       imagePullSecrets:
       - name: jarvice-docker
       volumes:
-      {{- include "jarvice.rootCertVolume" $ | indent 6 }}
+      {{- include "jarvice.rootCertVolume" . | indent 6 }}
       hostAliases:
-      {{- include "jarvice.hostAliases" (dict "Values" $.Values) | nindent 8 }}
+      {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
-      - name: jarvice-kns-scheduler-{{ .name }}
+      - name: jarvice-kns-scheduler
         command: ["python3"]
         args: ["/main", "Nested"]
-        image: {{ include "jarvice.registry" $ }}/{{ $.Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-kns-scheduler:{{ default $.Values.jarvice.JARVICE_IMAGES_TAG $.Chart.Annotations.tag }}{{- include "jarvice.version" $ }}
-{{- if and (empty $.Values.jarvice.JARVICE_IMAGES_VERSION) (empty $.Chart.Annotations.tag) }}
+        image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-kns-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}
         imagePullPolicy: IfNotPresent
@@ -149,186 +117,153 @@ spec:
             scheme: HTTP
             port: http
             path: /ready
-{{- if (not (empty .readinessProbe)) }}
-          initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ .readinessProbe.timeoutSeconds }}
-          successThreshold: {{ .readinessProbe.successThreshold }}
-          failureThreshold: {{ .readinessProbe.failureThreshold }}
-{{- else }}
-          initialDelaySeconds: {{ $.Values.jarvice_kns_scheduler.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ $.Values.jarvice_kns_scheduler.readinessProbe.periodSeconds }}
-          timeoutSeconds: {{ $.Values.jarvice_kns_scheduler.readinessProbe.timeoutSeconds }}
-          successThreshold: {{ $.Values.jarvice_kns_scheduler.readinessProbe.successThreshold }}
-          failureThreshold: {{ $.Values.jarvice_kns_scheduler.readinessProbe.failureThreshold }}
-{{- end }}
+          initialDelaySeconds: {{ .Values.jarvice_kns_scheduler.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.jarvice_kns_scheduler.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.jarvice_kns_scheduler.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.jarvice_kns_scheduler.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.jarvice_kns_scheduler.readinessProbe.failureThreshold }}
         livenessProbe:
           httpGet:
             scheme: HTTP
             port: http
             path: /live
-{{- if (not (empty .livenessProbe)) }}
-          initialDelaySeconds: {{ .livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ .livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ .livenessProbe.timeoutSeconds }}
-          successThreshold: {{ .livenessProbe.successThreshold }}
-          failureThreshold: {{ .livenessProbe.failureThreshold }}
-{{- else }}
-          initialDelaySeconds: {{ $.Values.jarvice_kns_scheduler.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ $.Values.jarvice_kns_scheduler.livenessProbe.periodSeconds }}
-          timeoutSeconds: {{ $.Values.jarvice_kns_scheduler.livenessProbe.timeoutSeconds }}
-          successThreshold: {{ $.Values.jarvice_kns_scheduler.livenessProbe.successThreshold }}
-          failureThreshold: {{ $.Values.jarvice_kns_scheduler.livenessProbe.failureThreshold }}
-{{- end }}
+          initialDelaySeconds: {{ .Values.jarvice_kns_scheduler.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.jarvice_kns_scheduler.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.jarvice_kns_scheduler.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.jarvice_kns_scheduler.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.jarvice_kns_scheduler.livenessProbe.failureThreshold }}
         env:
+{{- if (not (empty .Values.jarvice_kns_scheduler.env.JARVICE_KNS_KEEP_VCLUSTERS)) }}
           - name: JARVICE_KNS_KEEP_VCLUSTERS
-{{- if (not (empty .env.JARVICE_KNS_KEEP_VCLUSTERS)) }}
-            value: "{{ .env.JARVICE_KNS_KEEP_VCLUSTERS }}"
-{{- else }}
-            value: "{{ $.Values.jarvice_kns_scheduler.env.JARVICE_KNS_KEEP_VCLUSTERS }}"
+            value: "{{ .Values.jarvice_kns_scheduler.env.JARVICE_KNS_KEEP_VCLUSTERS }}"
 {{- end }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.env.JARVICE_KNS_DEFAULT_LIMIT_RANGE)) }}
           - name: JARVICE_KNS_DEFAULT_LIMIT_RANGE
-{{- if (not (empty .env.JARVICE_KNS_DEFAULT_LIMIT_RANGE)) }}
-            value: "{{ .env.JARVICE_KNS_DEFAULT_LIMIT_RANGE }}"
-{{- else }}
-            value: "{{ $.Values.jarvice_kns_scheduler.env.JARVICE_KNS_DEFAULT_LIMIT_RANGE }}"
+            value: "{{ .Values.jarvice_kns_scheduler.env.JARVICE_KNS_DEFAULT_LIMIT_RANGE }}"
 {{- end }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.env.JARVICE_KNS_VCLUSTER_SPAWN_DELAY)) }}
           - name: JARVICE_KNS_VCLUSTER_SPAWN_DELAY
-{{- if (not (empty .env.JARVICE_KNS_VCLUSTER_SPAWN_DELAY)) }}
-            value: "{{ .env.JARVICE_KNS_VCLUSTER_SPAWN_DELAY }}"
-{{- else }}
             value: "{{ $.Values.jarvice_kns_scheduler.env.JARVICE_KNS_VCLUSTER_SPAWN_DELAY }}"
 {{- end }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.env.JARVICE_KNS_INIT_IMAGE)) }}
           - name: JARVICE_KNS_INIT_IMAGE
-{{- if (not (empty .env.JARVICE_KNS_INIT_IMAGE)) }}
-            value: "{{ .env.JARVICE_KNS_INIT_IMAGE }}"
-{{- else }}
             value: "{{ $.Values.jarvice_kns_scheduler.env.JARVICE_KNS_INIT_IMAGE }}"
 {{- end }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.env.JARVICE_KNS_ALLOW_GOTTY_SHELL)) }}
           - name: JARVICE_KNS_ALLOW_GOTTY_SHELL
-{{- if (not (empty .env.JARVICE_KNS_ALLOW_GOTTY_SHELL)) }}
-            value: "{{ .env.JARVICE_KNS_ALLOW_GOTTY_SHELL }}"
-{{- else }}
             value: "{{ $.Values.jarvice_kns_scheduler.env.JARVICE_KNS_ALLOW_GOTTY_SHELL }}"
 {{- end }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.env.JARVICE_KNS_GOTTY_IMAGE)) }}
           - name: JARVICE_KNS_GOTTY_IMAGE
-{{- if (not (empty .env.JARVICE_KNS_GOTTY_IMAGE)) }}
-            value: "{{ .env.JARVICE_KNS_GOTTY_IMAGE }}"
-{{- else }}
             value: "{{ $.Values.jarvice_kns_scheduler.env.JARVICE_KNS_GOTTY_IMAGE }}"
 {{- end }}
+{{- if (not (empty .Values.jarvice_kns_scheduler.env.JARVICE_KNS_GOTTY_IMAGE_TAG)) }}
           - name: JARVICE_KNS_GOTTY_IMAGE_TAG
-{{- if (not (empty .env.JARVICE_KNS_GOTTY_IMAGE_TAG)) }}
-            value: "{{ .env.JARVICE_KNS_GOTTY_IMAGE_TAG }}"
-{{- else }}
             value: "{{ $.Values.jarvice_kns_scheduler.env.JARVICE_KNS_GOTTY_IMAGE_TAG }}"
 {{- end }}
           - name: JARVICE_SYSTEM_K8S
-{{- if empty $.Values.jarvice.JARVICE_SYSTEM_K8S }}
+{{- if empty .Values.jarvice.JARVICE_SYSTEM_K8S }}
             value: "true"
 {{- else }}
-            value: "{{ $.Values.jarvice.JARVICE_SYSTEM_K8S }}"
+            value: "{{ .Values.jarvice.JARVICE_SYSTEM_K8S }}"
 {{- end }}
           - name: JARVICE_EXPERIMENTAL
-{{- if empty $.Values.jarvice.JARVICE_EXPERIMENTAL }}
+{{- if empty .Values.jarvice.JARVICE_EXPERIMENTAL }}
             value: "false"
 {{- else }}
-            value: "{{ $.Values.jarvice.JARVICE_EXPERIMENTAL }}"
+            value: "{{ .Values.jarvice.JARVICE_EXPERIMENTAL }}"
 {{- end }}
           - name: JARVICE_CLUSTER_TYPE
-{{- if empty $.Values.jarvice.JARVICE_CLUSTER_TYPE }}
-            value: "upstream"
+{{- if empty .Values.jarvice.JARVICE_CLUSTER_TYPE }}
+            value: "downstream"
 {{- else }}
-            value: "{{ $.Values.jarvice.JARVICE_CLUSTER_TYPE }}"
-{{- end }}
-{{- if (not (eq "downstream" $.Values.jarvice.JARVICE_CLUSTER_TYPE)) }}
-          - name: JARVICE_DAL_URL
-            value: "http://jarvice-dal:8080"
-          - name: JARVICE_SCHED_URL
-            value: "https://jarvice-scheduler:9443"
-{{- end }}
-{{- if (not (empty .env.JARVICE_SCHED_SERVER_KEY)) }}
-          - name: JARVICE_SCHED_SERVER_KEY
-            valueFrom:
-              secretKeyRef:
-                name: jarvice-sched-kns-server-key-{{ .name }}
-                key: JARVICE_SCHED_SERVER_KEY
-                optional: true
+            value: "{{ .Values.jarvice.JARVICE_CLUSTER_TYPE }}"
 {{- end }}
           - name: JARVICE_JOBS_NAMESPACE
-{{- if empty $.Values.jarvice.JARVICE_JOBS_NAMESPACE }}
-            value: {{ $.Release.Namespace }}-jobs
+{{- if empty .Values.jarvice.JARVICE_JOBS_NAMESPACE }}
+            value: {{ .Release.Namespace }}-jobs
 {{- else }}
-            value: {{ $.Values.jarvice.JARVICE_JOBS_NAMESPACE }}
+            value: {{ .Values.jarvice.JARVICE_JOBS_NAMESPACE }}
 {{- end }}
           - name: JARVICE_SYSTEM_NAMESPACE
-{{- if empty $.Values.jarvice.JARVICE_SYSTEM_NAMESPACE }}
-            value: {{ $.Release.Namespace }}
+{{- if empty .Values.jarvice.JARVICE_SYSTEM_NAMESPACE }}
+            value: {{ .Release.Namespace }}
 {{- else }}
-            value: {{ $.Values.jarvice.JARVICE_SYSTEM_NAMESPACE }}
+            value: {{ .Values.jarvice.JARVICE_SYSTEM_NAMESPACE }}
 {{- end }}
           - name: JARVICE_SYSTEM_REGISTRY
-            value: {{ include "jarvice.registry" $ }}
+            value: {{ include "jarvice.registry" . }}
           - name: JARVICE_SYSTEM_REPO_BASE
-            value: {{ $.Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}
+            value: {{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}
           - name: JARVICE_IMAGES_TAG
-            value: {{ default $.Values.jarvice.JARVICE_IMAGES_TAG $.Chart.Annotations.tag }}{{- include "jarvice.version" $ }}
+            value: {{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
           - name: JARVICE_LOCAL_REGISTRY
-            value: {{ $.Values.jarvice.JARVICE_LOCAL_REGISTRY }}
+            value: {{ .Values.jarvice.JARVICE_LOCAL_REGISTRY }}
           - name: JARVICE_LOCAL_REPO_BASE
-            value: {{ $.Values.jarvice.JARVICE_LOCAL_REPO_BASE }}
-          - name: JARVICE_JOBS_DOMAIN
-{{- if (hasPrefix "lookup" $.Values.jarvice.JARVICE_JOBS_DOMAIN) }}
-{{- if (eq "downstream" $.Values.jarvice.JARVICE_CLUSTER_TYPE) }}
-            value: '{{- .ingressHost -}}{{- trimPrefix "lookup" $.Values.jarvice.JARVICE_JOBS_DOMAIN -}}'
+            value: {{ .Values.jarvice.JARVICE_LOCAL_REPO_BASE }}
+          - name: JARVICE_K8S_ADMIN_CONF
+            value: "{{ .Values.jarvice_kns_scheduler.env.JARVICE_K8S_ADMIN_CONF }}"
+          - name: JARVICE_SCHED_PLUGIN_USE
+            value: "true"
+{{- if (not (empty .Values.jarvice.JARVICE_HTTP_PROXY)) }}
+          - name: http_proxy
+            value: "{{ .Values.jarvice.JARVICE_HTTP_PROXY }}"
+{{- end }}
+{{- if (not (empty .Values.jarvice.JARVICE_HTTPS_PROXY)) }}
+          - name: https_proxy
+            value: "{{ .Values.jarvice.JARVICE_HTTPS_PROXY }}"
+{{- end }}
+{{- if or .Values.jarvice.JARVICE_HTTPS_PROXY .Values.jarvice.JARVICE_HTTP_PROXY .Values.jarvice.JARVICE_NO_PROXY }}
+{{- if (not (empty .Values.jarvice.JARVICE_NO_PROXY)) }}
+          - name: no_proxy
+            value: '{{ include "jarvice.no_proxy" . }},{{ .Values.jarvice.JARVICE_NO_PROXY }}'
 {{- else }}
-            value: '{{- $.Values.jarvice_mc_portal.ingressHost -}}{{- trimPrefix "lookup" $.Values.jarvice.JARVICE_JOBS_DOMAIN -}}'
+          - name: no_proxy
+            value: '{{ include "jarvice.no_proxy" . }}'
+{{- end }}
+{{- end }}
+{{- if (not (empty .Values.jarvice.JARVICE_JOBS_DOMAIN)) }}
+          - name: JARVICE_JOBS_DOMAIN
+{{- if (hasPrefix "lookup" .Values.jarvice.JARVICE_JOBS_DOMAIN) }}
+{{- if (eq "downstream" .Values.jarvice.JARVICE_CLUSTER_TYPE) }}
+            value: '{{- .Values.jarvice_kns_scheduler.ingressHost -}}{{- trimPrefix "lookup" .Values.jarvice.JARVICE_JOBS_DOMAIN -}}'
+{{- else }}
+            value: '{{- .Values.jarvice_mc_portal.ingressHost -}}{{- trimPrefix "lookup" .Values.jarvice.JARVICE_JOBS_DOMAIN -}}'
 {{- end }}
 {{- else }}
-            value: "{{ $.Values.jarvice.JARVICE_JOBS_DOMAIN }}"
+            value: "{{ .Values.jarvice.JARVICE_JOBS_DOMAIN }}"
+{{- end }}
 {{- end }}
           - name: JARVICE_JOBS_INGRESS_CLASS
-            value: "{{ $.Values.jarvice.ingress.class }}"
+            value: "{{ .Values.jarvice.ingress.class }}"
           - name: JARVICE_JOBS_INGRESS_ANNOTATIONS
-            value: '{{ $.Values.jarvice.JARVICE_JOBS_INGRESS_ANNOTATIONS }}'
-{{- if (not (empty $.Values.jarvice.ingress.tls.issuer.name)) }}
-          - name: JARVICE_JOBS_INGRESS_CERT_ISSUER
-            value: "{{ $.Values.jarvice.ingress.tls.issuer.name }}"
-{{- else if (not (empty $.Values.jarvice.ingress.tls.cluster_issuer.name)) }}
-          - name: JARVICE_JOBS_INGRESS_CERT_CLUSTER_ISSUER
-            value: "{{ $.Values.jarvice.ingress.tls.cluster_issuer.name }}"
-{{- end }}
-{{- if (not (empty $.Values.jarvice.JARVICE_HTTP_PROXY)) }}
-          - name: http_proxy
-            value: "{{ $.Values.jarvice.JARVICE_HTTP_PROXY }}"
-{{- end }}
-{{- if (not (empty $.Values.jarvice.JARVICE_HTTPS_PROXY)) }}
-          - name: https_proxy
-            value: "{{ $.Values.jarvice.JARVICE_HTTPS_PROXY }}"
-{{- end }}
-{{- if or $.Values.jarvice.JARVICE_HTTPS_PROXY $.Values.jarvice.JARVICE_HTTP_PROXY $.Values.jarvice.JARVICE_NO_PROXY }}
-{{- if (not (empty $.Values.jarvice.JARVICE_NO_PROXY)) }}
-          - name: no_proxy
-            value: '{{ include "jarvice.no_proxy" $ }},{{ $.Values.jarvice.JARVICE_NO_PROXY }}'
+            value: '{{ .Values.jarvice.JARVICE_JOBS_INGRESS_ANNOTATIONS }}'
+{{- if and (not (empty .Values.jarvice.ingress.tls.crt)) (not (empty .Values.jarvice.ingress.tls.key)) }}
+          - name: JARVICE_JOBS_INGRESS_CERT_SECRET_NAME
+            value: "tls-jarvice"
 {{- else }}
-          - name: no_proxy
-            value: '{{ include "jarvice.no_proxy" $ }}'
+{{- if (not (empty .Values.jarvice.ingress.tls.issuer.name)) }}
+          - name: JARVICE_JOBS_INGRESS_CERT_ISSUER
+            value: "{{ .Values.jarvice.ingress.tls.issuer.name }}"
+{{- else if (not (empty .Values.jarvice.ingress.tls.cluster_issuer.name)) }}
+          - name: JARVICE_JOBS_INGRESS_CERT_CLUSTER_ISSUER
+            value: "{{ .Values.jarvice.ingress.tls.cluster_issuer.name }}"
 {{- end }}
 {{- end }}
-        volumeMounts:
-        {{- include "jarvice.rootCertVolumeMount" $ | indent 8 }}
+          - name: JARVICE_K8S_SCHED_LOGLEVEL
+            value: "{{ .Values.jarvice.JARVICE_K8S_SCHED_LOGLEVEL }}"
         resources:
-{{- if .resources }}
-{{ toYaml .resources | indent 10 }}
+{{- if .Values.jarvice_kns_scheduler.resources }}
+{{ toYaml .Values.jarvice_kns_scheduler.resources | indent 10 }}
 {{- end }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: jarvice-kns-scheduler-{{ .name }}
+  name: jarvice-kns-scheduler
   labels:
-    {{- include "jarvice.release_labels" $ | indent 4 }}
-    component: jarvice-kns-scheduler-{{ .name }}
+    {{- include "jarvice.release_labels" . | indent 4 }}
+    component: jarvice-kns-scheduler
 spec:
   type: ClusterIP
   ports:
@@ -337,30 +272,30 @@ spec:
     targetPort: 8080
     name: http
   selector:
-    deployment: jarvice-kns-scheduler-{{ .name }}
+    deployment: jarvice-kns-scheduler
 ---
-{{- if or $.Values.jarvice_kns_scheduler.networkPolicy.enabled $.Values.jarvice.networkPolicy.enabled }}
+{{- if or .Values.jarvice_kns_scheduler.networkPolicy.enabled (and (eq "<nil>" (toString .Values.jarvice_kns_scheduler.networkPolicy.enabled)) .Values.jarvice.networkPolicy.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: jarvice-kns-scheduler-{{ .name }}
+  name: jarvice-kns-scheduler
 spec:
   podSelector:
     matchLabels:
-      deployment: jarvice-kns-scheduler-{{ .name }}
+      deployment: jarvice-kns-scheduler
   policyTypes:
   - Ingress
   ingress:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: {{ $.Release.Namespace }}
+          name: {{ .Release.Namespace }}
     - podSelector: {}
     ports:
     - protocol: TCP
       port: 8080
-{{- if (eq "downstream" $.Values.jarvice.JARVICE_CLUSTER_TYPE) }}
-{{- if (empty .ingressHost) }}
+{{- if (eq "downstream" .Values.jarvice.JARVICE_CLUSTER_TYPE) }}
+{{- if (empty .Values.jarvice_kns_scheduler.ingressHost) }}
   - {}
 {{- else }}
   - from:
@@ -373,88 +308,88 @@ spec:
 {{- end }}
 ---
 {{- end }}
-{{- if (eq "downstream" $.Values.jarvice.JARVICE_CLUSTER_TYPE) }}
-{{- if (empty .ingressHost) }}
+{{- if (eq "downstream" .Values.jarvice.JARVICE_CLUSTER_TYPE) }}
+{{- if (empty .Values.jarvice_kns_scheduler.ingressHost) }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: jarvice-kns-scheduler-{{ .name }}-lb
+  name: jarvice-kns-scheduler-lb
   labels:
-    {{- include "jarvice.release_labels" $ | indent 4 }}
-    component: jarvice-kns-scheduler-{{ .name }}
+    {{- include "jarvice.release_labels" . | indent 4 }}
+    component: jarvice-kns-scheduler
 spec:
   type: LoadBalancer
-  loadBalancerIP: {{ .loadBalancerIP }}
+  loadBalancerIP: {{ .Values.jarvice_kns_scheduler.loadBalancerIP }}
   ports:
   - protocol: TCP
     port: 8080
     targetPort: 8080
     name: http
   selector:
-    deployment: jarvice-kns-scheduler-{{ .name }}
+    deployment: jarvice-kns-scheduler
 ---
 {{- else }}
-{{- if (semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: jarvice-kns-scheduler-{{ .name }}
+  name: jarvice-kns-scheduler
   labels:
-    {{- include "jarvice.release_labels" $ | indent 4 }}
-    component: jarvice-kns-scheduler-{{ .name }}
+    {{- include "jarvice.release_labels" . | indent 4 }}
+    component: jarvice-kns-scheduler
   annotations:
-{{- if (not (semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion)) }}
-{{- if (not (empty $.Values.jarvice.ingress.class)) }}
-    kubernetes.io/ingress.class: {{ $.Values.jarvice.ingress.class }}
+{{- if (not (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if (not (empty .Values.jarvice.ingress.class)) }}
+    kubernetes.io/ingress.class: {{ .Values.jarvice.ingress.class }}
 {{- end }}
 {{- end }}
-{{- if and (not (empty $.Values.jarvice.ingress.tls.issuer.name)) (and (empty $.Values.jarvice.ingress.tls.crt) (empty $.Values.jarvice.ingress.tls.key)) }}
-    cert-manager.io/issuer: {{ $.Values.jarvice.ingress.tls.issuer.name }}
-{{- else if and (not (empty $.Values.jarvice.ingress.tls.cluster_issuer.name)) (and (empty $.Values.jarvice.ingress.tls.crt) (empty $.Values.jarvice.ingress.tls.key)) }}
-    cert-manager.io/cluster-issuer: {{ $.Values.jarvice.ingress.tls.cluster_issuer.name }}
+{{- if and (not (empty .Values.jarvice.ingress.tls.issuer.name)) (and (empty .Values.jarvice.ingress.tls.crt) (empty .Values.jarvice.ingress.tls.key)) }}
+    cert-manager.io/issuer: {{ .Values.jarvice.ingress.tls.issuer.name }}
+{{- else if and (not (empty .Values.jarvice.ingress.tls.cluster_issuer.name)) (and (empty .Values.jarvice.ingress.tls.crt) (empty .Values.jarvice.ingress.tls.key)) }}
+    cert-manager.io/cluster-issuer: {{ .Values.jarvice.ingress.tls.cluster_issuer.name }}
 {{- end }}
-{{- if .ingressAnnotations }}
-{{- if (kindIs "string" .ingressAnnotations) }}
-{{ toYaml (fromJson .ingressAnnotations) | indent 4 }}
+{{- if .Values.jarvice_kns_scheduler.ingressAnnotations }}
+{{- if (kindIs "string" .Values.jarvice_kns_scheduler.ingressAnnotations) }}
+{{ toYaml (fromJson .Values.jarvice_kns_scheduler.ingressAnnotations) | indent 4 }}
 {{- else }}
-{{ toYaml .ingressAnnotations | indent 4 }}
+{{ toYaml .Values.jarvice_kns_scheduler.ingressAnnotations | indent 4 }}
 {{- end }}
 {{- end }}
 spec:
-{{- if (semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion) }}
-{{- if (not (empty $.Values.jarvice.ingress.class)) }}
-  ingressClassName: {{ $.Values.jarvice.ingress.class }}
+{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
+{{- if (not (empty .Values.jarvice.ingress.class)) }}
+  ingressClassName: {{ .Values.jarvice.ingress.class }}
 {{- end }}
 {{- end }}
   rules:
   - http:
       paths:
-{{- if (semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion) }}
+{{- if (semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion) }}
       - backend:
           service:
-            name: jarvice-kns-scheduler-{{ .name }}
+            name: jarvice-kns-scheduler
             port:
               name: http
         pathType: Prefix
         path: /
 {{- else }}
       - backend:
-          serviceName: jarvice-kns-scheduler-{{ .name }}
+          serviceName: jarvice-kns-scheduler
           servicePort: http
 {{- end }}
-{{- if ne "-" .ingressHost }}
-    host: '{{- .ingressHost -}}'
-{{- if or (not (empty $.Values.jarvice.ingress.tls.cluster_issuer.name)) (not (empty $.Values.jarvice.ingress.tls.issuer.name)) (and (not (empty $.Values.jarvice.ingress.tls.crt)) (not (empty $.Values.jarvice.ingress.tls.key))) }}
+{{- if ne "-" .Values.jarvice_kns_scheduler.ingressHost }}
+    host: '{{- .Values.jarvice_kns_scheduler.ingressHost -}}'
+{{- if or (not (empty .Values.jarvice.ingress.tls.cluster_issuer.name)) (not (empty .Values.jarvice.ingress.tls.issuer.name)) (and (not (empty .Values.jarvice.ingress.tls.crt)) (not (empty .Values.jarvice.ingress.tls.key))) }}
   tls:
   - hosts:
-    - '{{- .ingressHost -}}'
-{{- if and (not (empty $.Values.jarvice.ingress.tls.crt)) (not (empty $.Values.jarvice.ingress.tls.key)) }}
+    - '{{- .Values.jarvice_kns_scheduler.ingressHost -}}'
+{{- if and (not (empty .Values.jarvice.ingress.tls.crt)) (not (empty .Values.jarvice.ingress.tls.key)) }}
     secretName: 'tls-jarvice'
 {{- else }}
-    secretName: 'tls-{{- .ingressHost -}}'
+    secretName: 'tls-{{- .Values.jarvice_kns_scheduler.ingressHost -}}'
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -922,13 +922,13 @@ jarvice_kns_scheduler:
   nodeAffinity: # '{"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "node-role.jarvice.io/jarvice-kns-scheduler", "operator": "Exists"}]}] }}'
   nodeSelector: # '{"node-role.jarvice.io/jarvice-kns-scheduler": "true"}'
   env:
-    JARVICE_KNS_KEEP_VCLUSTERS: ""
+    JARVICE_KNS_KEEP_VCLUSTERS: "false"
     JARVICE_KNS_DEFAULT_LIMIT_RANGE: ""
-    JARVICE_KNS_VCLUSTER_SPAWN_DELAY: ""
-    JARVICE_KNS_INIT_IMAGE: ""
-    JARVICE_KNS_ALLOW_GOTTY_SHELL: ""
-    JARVICE_KNS_GOTTY_IMAGE: ""
-    JARVICE_KNS_GOTTY_IMAGE_TAG: ""
+    JARVICE_KNS_VCLUSTER_SPAWN_DELAY: 300
+    JARVICE_KNS_INIT_IMAGE: "us-docker.pkg.dev/jarvice/images/init-kns"
+    JARVICE_KNS_ALLOW_GOTTY_SHELL: "false"
+    JARVICE_KNS_GOTTY_IMAGE: "us-docker.pkg.dev/jarvice/images/kns-gotty"
+    JARVICE_KNS_GOTTY_IMAGE_TAG: "n1.3.0"
 
 jarvice_pod_scheduler:
   enabled: true


### PR DESCRIPTION
I used the slurm template as source the first time.
I changed that and used the k8s scheduler template one instead.

I validated that using:

`helm upgrade jarvice ./ --install --debug --dry-run   --namespace jarvice-system  --set jarvice.imagePullSecret="toto" --set jarvice.JARVICE_LICENSE_LIC="tutu" --set jarvice_kns_scheduler.enabled=true -f values.yaml
`
Rendered elements seems ok to me. However, since I am not confident with Helm, I did not dare testing it for real on our clusters for now, and my laptop cannot handle such load.