### PR TITLE
JAR-9272

### DIFF
--- a/templates/jarvice-kns-scheduler.yaml
+++ b/templates/jarvice-kns-scheduler.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kns-sa
-  namespace: jarvice-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -13,7 +12,6 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: kns-sa
-  namespace: jarvice-system
 roleRef:
   kind: ClusterRole
   name: cluster-admin


### PR DESCRIPTION
Remove hardcoded jarvice-system namespace.
I could not find anything else on the KNS side in the other parts of jarvice or jarvice-helm about this namespace being hardcoded.