### PR TITLE
Fix JAR-9611

### DIFF
--- a/templates/jarvice-api.yaml
+++ b/templates/jarvice-api.yaml
@@ -116,7 +116,7 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTP
-            port: http
+            port: 8080
             path: /jarvice/ready
           initialDelaySeconds: {{ .Values.jarvice_api.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.jarvice_api.readinessProbe.periodSeconds }}
@@ -126,7 +126,7 @@ spec:
         livenessProbe:
           httpGet:
             scheme: HTTP
-            port: http
+            port: 8080
             path: /jarvice/live
           initialDelaySeconds: {{ .Values.jarvice_api.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.jarvice_api.livenessProbe.periodSeconds }}
@@ -391,7 +391,7 @@ spec:
         livenessProbe:
           httpGet:
             scheme: HTTP
-            port: http
+            port: 8000
             path: {{ .Values.jarvice_api.external.env.JARVICE_EXTERNAL_BILLING_PAHT }}/live
           initialDelaySeconds: {{ .Values.jarvice_api.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.jarvice_api.livenessProbe.periodSeconds }}

--- a/templates/jarvice-dal.yaml
+++ b/templates/jarvice-dal.yaml
@@ -124,7 +124,7 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTP
-            port: http
+            port: 8080
             path: /ready
           initialDelaySeconds: {{ .Values.jarvice_dal.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.jarvice_dal.readinessProbe.periodSeconds }}
@@ -134,7 +134,7 @@ spec:
         livenessProbe:
           httpGet:
             scheme: HTTP
-            port: http
+            port: 8080
             path: /live
           initialDelaySeconds: {{ .Values.jarvice_dal.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.jarvice_dal.livenessProbe.periodSeconds }}


### PR DESCRIPTION
There is a regression in Kubernetes that treats the http string as a literal, and fails to look it up, resulting in livenessprobe and readynessprobe fails.

This needs to be updated to fix this and work around it.