### PR TITLE
Jar 9995 omit system repo base for helm

### DIFF
--- a/templates/jarvice-api.yaml
+++ b/templates/jarvice-api.yaml
@@ -104,7 +104,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-api
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-api:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-api:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}
@@ -372,7 +376,11 @@ spec:
         resources:
 {{ toYaml .Values.jarvice_api.resources | indent 10 }}
       - name: jarvice-api-v1
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-api-v1:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-api-v1:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-appsync.yaml
+++ b/templates/jarvice-appsync.yaml
@@ -50,7 +50,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-appsync
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-appsync:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-appsync:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-bird.yaml
+++ b/templates/jarvice-bird.yaml
@@ -159,7 +159,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-bird
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-bird:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-bird:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}
@@ -243,7 +247,11 @@ spec:
         resources:
 {{ toYaml .Values.jarvice_bird.bird.resources | indent 10 }}
       - name: jarvice-bird-portal
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-bird-portal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-bird-portal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}
@@ -600,7 +608,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-bird-server
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-bird-server:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-bird-server:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-dal.yaml
+++ b/templates/jarvice-dal.yaml
@@ -112,7 +112,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-dal
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-dal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-dal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-db-dump.yaml
+++ b/templates/jarvice-db-dump.yaml
@@ -107,7 +107,11 @@ spec:
 {{- else }}
                 value: "nginx"
 {{- end }}
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+            image: {{ include "jarvice.registry" . }}/jarvice-dal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
             image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-dal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
             imagePullPolicy: IfNotPresent
             name: jarvice-db-dump-init
             securityContext:
@@ -117,7 +121,11 @@ spec:
               name: jarvice-db-dump-dir
           containers:
           - name: jarvice-db-dump
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+            image: {{ include "jarvice.registry" . }}/jarvice-dal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
             image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-dal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
             imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-hyperhub.yaml
+++ b/templates/jarvice-hyperhub.yaml
@@ -81,7 +81,11 @@ spec:
         name: nginx-config
       containers:
       - name: jarvice-hyperhub
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-hyperhub:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-hyperhub:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-k8s-scheduler.yaml
+++ b/templates/jarvice-k8s-scheduler.yaml
@@ -80,7 +80,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-k8s-scheduler
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-k8s-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-k8s-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}
@@ -188,6 +192,12 @@ spec:
             value: {{ include "jarvice.registry" . }}
           - name: JARVICE_SYSTEM_REPO_BASE
             value: {{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}
+          - name: JARVICE_SYSTEM_OMIT_REPO_BASE
+{{- if empty .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+            value: "false"
+{{- else }}
+            value: "{{ .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}"
+{{- end }}
           - name: JARVICE_IMAGES_TAG
             value: {{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
           - name: JARVICE_LOCAL_REGISTRY

--- a/templates/jarvice-kns-scheduler.yaml
+++ b/templates/jarvice-kns-scheduler.yaml
@@ -102,7 +102,11 @@ spec:
       - name: jarvice-kns-scheduler
         command: ["python3"]
         args: ["/main", "Nested"]
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{- if (empty .Values.jarvice_kns_scheduler.imageTag ) }}{{ include "jarvice.registry" . }}/jarvice-k8s-nested-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}{{- else }}{{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-k8s-nested-scheduler:{{ default .Values.jarvice_kns_scheduler.imageTag .Chart.Annotations.tag }}{{- include "jarvice.version" . }}{{- end }}
+{{- else }}
         image: {{- if (empty .Values.jarvice_kns_scheduler.imageTag ) }}{{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-k8s-nested-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}{{- else }}{{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-k8s-nested-scheduler:{{ default .Values.jarvice_kns_scheduler.imageTag .Chart.Annotations.tag }}{{- include "jarvice.version" . }}{{- end }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-license-manager.yaml
+++ b/templates/jarvice-license-manager.yaml
@@ -60,7 +60,11 @@ spec:
 {{- end }}
       containers:
       - name: jarvice-license-manager
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-license-manager:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-license-manager:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-mc-portal.yaml
+++ b/templates/jarvice-mc-portal.yaml
@@ -119,7 +119,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-mc-portal
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-mc-portal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-mc-portal:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-pod-scheduler.yaml
+++ b/templates/jarvice-pod-scheduler.yaml
@@ -47,7 +47,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-pod-scheduler
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-pod-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-pod-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-sched-pass.yaml
+++ b/templates/jarvice-sched-pass.yaml
@@ -86,7 +86,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-sched-pass
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-sched-pass:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-sched-pass:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-scheduler.yaml
+++ b/templates/jarvice-scheduler.yaml
@@ -88,7 +88,11 @@ spec:
       {{- include "jarvice.hostAliases" . | nindent 8 }}
       containers:
       - name: jarvice-scheduler
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" . }}/jarvice-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- else }}
         image: {{ include "jarvice.registry" . }}/{{ .Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-scheduler:{{ default .Values.jarvice.JARVICE_IMAGES_TAG .Chart.Annotations.tag }}{{- include "jarvice.version" . }}
+{{- end }}
 {{- if and (empty .Values.jarvice.JARVICE_IMAGES_VERSION) (empty .Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}

--- a/templates/jarvice-slurm-scheduler.yaml
+++ b/templates/jarvice-slurm-scheduler.yaml
@@ -113,7 +113,11 @@ spec:
       {{- include "jarvice.hostAliases" (dict "Values" $.Values) | nindent 8 }}
       containers:
       - name: jarvice-slurm-scheduler-{{ .name }}
+{{- if .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+        image: {{ include "jarvice.registry" $ }}/jarvice-slurm-scheduler:{{ default $.Values.jarvice.JARVICE_IMAGES_TAG $.Chart.Annotations.tag }}{{- include "jarvice.version" $ }}
+{{- else }}
         image: {{ include "jarvice.registry" $ }}/{{ $.Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}/jarvice-slurm-scheduler:{{ default $.Values.jarvice.JARVICE_IMAGES_TAG $.Chart.Annotations.tag }}{{- include "jarvice.version" $ }}
+{{- end }}
 {{- if and (empty $.Values.jarvice.JARVICE_IMAGES_VERSION) (empty $.Chart.Annotations.tag) }}
         imagePullPolicy: Always
 {{- else }}
@@ -248,6 +252,12 @@ spec:
             value: {{ include "jarvice.registry" $ }}
           - name: JARVICE_SYSTEM_REPO_BASE
             value: {{ $.Values.jarvice.JARVICE_SYSTEM_REPO_BASE }}
+          - name: JARVICE_SYSTEM_OMIT_REPO_BASE
+{{- if empty .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}
+            value: "false"
+{{- else }}
+            value: "{{ .Values.jarvice.JARVICE_SYSTEM_OMIT_REPO_BASE }}"
+{{- end }}
           - name: JARVICE_IMAGES_TAG
             value: {{ default $.Values.jarvice.JARVICE_IMAGES_TAG $.Chart.Annotations.tag }}{{- include "jarvice.version" $ }}
           - name: JARVICE_LOCAL_REGISTRY

--- a/values.yaml
+++ b/values.yaml
@@ -22,6 +22,11 @@ jarvice:
 
   JARVICE_SYSTEM_REGISTRY: us-docker.pkg.dev
   JARVICE_SYSTEM_REPO_BASE: jarvice-system/images
+  # Enable JARVICE_SYSTEM_OMIT_REPO_BASE only in special use-case instances
+  # For example SMC-xScale v2 requires that JARVICE_SYSTEM_REPO_BASE not
+  # be used in image paths - so enabling this will prevent that
+  JARVICE_SYSTEM_OMIT_REPO_BASE: false
+
   JARVICE_IMAGES_TAG: jarvice-master
   JARVICE_IMAGES_VERSION: # auto-set (ignored) if installing from chart repo
 


### PR DESCRIPTION
Add option in helm chart to prevent using JARVICE_SYSTEM_REPO_BASE in image url references