### PR TITLE
Fix: JAR-10314 - Make kns_node_pools optional and fix label for nvidia GPU

### DIFF
--- a/templates/jarvice-kns-scheduler.yaml
+++ b/templates/jarvice-kns-scheduler.yaml
@@ -31,7 +31,7 @@ spec:
   selector:
     matchLabels:
       deployment: jarvice-kns-scheduler
-  minAvailable: {{ .Values.jarvice_kns_scheduler.pdb.minAvailable }}
+  minAvailable: {{ .Values.jarvice_kns_scheduler.pdb.minAvailable | default "25%" }}
 ---
 {{- end }}
 apiVersion: apps/v1
@@ -58,7 +58,6 @@ spec:
       annotations:
         deployment-date: {{ now | quote }}
     spec:
-      serviceAccount: kns-sa
       serviceAccountName: kns-sa
 {{- if (not (empty .Values.jarvice_kns_scheduler.tolerations)) }}
       tolerations: {{ .Values.jarvice_kns_scheduler.tolerations }}

--- a/terraform/modules/gkev2/main.tf
+++ b/terraform/modules/gkev2/main.tf
@@ -373,7 +373,7 @@ resource "google_container_node_pool" "jarvice_compute" {
                 "node-pool.jarvice.io/disable-hyperthreading" = lower(lookup(each.value.meta, "disable_hyperthreading", "false")) == "true" ? "true" : "false"
             },
             lookup(each.value.meta, "enable_gcfs", null) != null ? {"node-pool.jarvice.io/enable-gcfs" = lower(each.value.meta["enable_gcfs"]) == "true" ? "true" : "false"} : {},
-            lookup(each.value.meta, "accelerator_type", "") != "" && contains(lower(lookup(each.value.meta, "accelerator_type", "")), "nvidia") ? {"nvidia.com/gpu" = "true"} : {}
+            lookup(each.value.meta, "accelerator_type", "") != "" && contains([lower(lookup(each.value.meta, "accelerator_type", ""))], "nvidia") ? {"nvidia.com/gpu" = "true"} : {}
         )
         taint = [
             {

--- a/terraform/modules/gkev2/main.tf
+++ b/terraform/modules/gkev2/main.tf
@@ -329,7 +329,7 @@ resource "google_container_node_pool" "jarvice_compute" {
     autoscaling {
         min_node_count = each.value["nodes_min"]
         max_node_count = each.value["nodes_max"]
-        total_max_node_count = each.value["nodes_max"] * length(local.zones)
+        total_max_node_count = each.value["nodes_max"]
     }
 
     management {
@@ -406,7 +406,7 @@ resource "google_container_node_pool" "jarvice_kns" {
     autoscaling {
         min_node_count = each.value["nodes_min"]
         max_node_count = each.value["nodes_max"]
-        total_max_node_count = each.value["nodes_max"] * length(local.zones)
+        total_max_node_count = each.value["nodes_max"]
     }
 
     management {

--- a/terraform/modules/gkev2/main.tf
+++ b/terraform/modules/gkev2/main.tf
@@ -329,7 +329,6 @@ resource "google_container_node_pool" "jarvice_compute" {
     autoscaling {
         min_node_count = each.value["nodes_min"]
         max_node_count = each.value["nodes_max"]
-        total_max_node_count = each.value["nodes_max"]
     }
 
     management {
@@ -406,7 +405,6 @@ resource "google_container_node_pool" "jarvice_kns" {
     autoscaling {
         min_node_count = each.value["nodes_min"]
         max_node_count = each.value["nodes_max"]
-        total_max_node_count = each.value["nodes_max"]
     }
 
     management {

--- a/terraform/modules/gkev2/main.tf
+++ b/terraform/modules/gkev2/main.tf
@@ -329,6 +329,7 @@ resource "google_container_node_pool" "jarvice_compute" {
     autoscaling {
         min_node_count = each.value["nodes_min"]
         max_node_count = each.value["nodes_max"]
+        total_max_node_count = each.value["nodes_max"] * length(local.zones)
     }
 
     management {
@@ -405,6 +406,7 @@ resource "google_container_node_pool" "jarvice_kns" {
     autoscaling {
         min_node_count = each.value["nodes_min"]
         max_node_count = each.value["nodes_max"]
+        total_max_node_count = each.value["nodes_max"] * length(local.zones)
     }
 
     management {

--- a/terraform/modules/gkev2/main.tf
+++ b/terraform/modules/gkev2/main.tf
@@ -373,6 +373,7 @@ resource "google_container_node_pool" "jarvice_compute" {
                 "node-pool.jarvice.io/disable-hyperthreading" = lower(lookup(each.value.meta, "disable_hyperthreading", "false")) == "true" ? "true" : "false"
             },
             lookup(each.value.meta, "enable_gcfs", null) != null ? {"node-pool.jarvice.io/enable-gcfs" = lower(each.value.meta["enable_gcfs"]) == "true" ? "true" : "false"} : {},
+            lookup(each.value.meta, "accelerator_type", "") != "" && contains(lower(lookup(each.value.meta, "accelerator_type", "")), "nvidia") ? {"nvidia.com/gpu" = "true"} : {}
         )
         taint = [
             {
@@ -447,6 +448,8 @@ resource "google_container_node_pool" "jarvice_kns" {
                 "node-pool.jarvice.io/disable-hyperthreading" = lower(lookup(each.value.meta, "disable_hyperthreading", "false")) == "true" ? "true" : "false"
             },
             lookup(each.value.meta, "enable_gcfs", null) != null ? {"node-pool.jarvice.io/enable-gcfs" = lower(each.value.meta["enable_gcfs"]) == "true" ? "true" : "false"} : {},
+            lookup(each.value.meta, "accelerator_type", "") != "" && contains(lower(lookup(each.value.meta, "accelerator_type", "")), "nvidia") ? {"nvidia.com/gpu" = "true"} : {}
+
         )
         taint = [
             {

--- a/terraform/modules/gkev2/main.tf
+++ b/terraform/modules/gkev2/main.tf
@@ -374,7 +374,7 @@ resource "google_container_node_pool" "jarvice_compute" {
                 "node-pool.jarvice.io/disable-hyperthreading" = lower(lookup(each.value.meta, "disable_hyperthreading", "false")) == "true" ? "true" : "false"
             },
             lookup(each.value.meta, "enable_gcfs", null) != null ? {"node-pool.jarvice.io/enable-gcfs" = lower(each.value.meta["enable_gcfs"]) == "true" ? "true" : "false"} : {},
-            lookup(each.value.meta, "accelerator_type", "") != "" && contains([lower(lookup(each.value.meta, "accelerator_type", ""))], "nvidia") ? {"nvidia.com/gpu" = "true"} : {}
+            lookup(each.value.meta, "accelerator_type", "") != "" && can(regex("nvidia", lower(trimspace(lookup(each.value.meta, "accelerator_type", ""))))) ? {"nvidia.com/gpu" = "present"} : {}
         )
         taint = [
             {
@@ -450,8 +450,7 @@ resource "google_container_node_pool" "jarvice_kns" {
                 "node-pool.jarvice.io/disable-hyperthreading" = lower(lookup(each.value.meta, "disable_hyperthreading", "false")) == "true" ? "true" : "false"
             },
             lookup(each.value.meta, "enable_gcfs", null) != null ? {"node-pool.jarvice.io/enable-gcfs" = lower(each.value.meta["enable_gcfs"]) == "true" ? "true" : "false"} : {},
-            lookup(each.value.meta, "accelerator_type", "") != "" && contains(lower(lookup(each.value.meta, "accelerator_type", "")), "nvidia") ? {"nvidia.com/gpu" = "true"} : {}
-
+            lookup(each.value.meta, "accelerator_type", "") != "" && can(regex("nvidia", lower(trimspace(lookup(each.value.meta, "accelerator_type", ""))))) ? {"nvidia.com/gpu" = "present"} : {}
         )
         taint = [
             {

--- a/terraform/modules/gkev2/variables.tf
+++ b/terraform/modules/gkev2/variables.tf
@@ -42,14 +42,14 @@ variable "cluster" {
             nodes_max = number
             meta = map(string)
         }))
-        kns_node_pools = map(object({
+        kns_node_pools = optional(map(object({
             nodes_type = string
             nodes_disk_size_gb = number
             nodes_num = number
             nodes_min = number
             nodes_max = number
             meta = map(string)
-        }))
+        })))
         helm = map(
             map(string)
         )


### PR DESCRIPTION
Make kns_node_pools optional and fix label for nvidia GPU if accelerator of type nvidia is used.