### PR TITLE
Fix: JAR-10394 - Adds metadata labels to jarvice-system namespace

### DIFF
--- a/templates/jarvice-helm-hook.yaml
+++ b/templates/jarvice-helm-hook.yaml
@@ -90,6 +90,78 @@ spec:
 {{- end }}
       serviceAccountName: jarvice-system
 {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jarvice-label-ns
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: label-ns
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  resourceNames: ["{{ .Release.Namespace }}"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Namespace }}:label-ns
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+subjects:
+  - kind: ServiceAccount
+    name: "jarvice-label-ns"
+roleRef:
+  kind: Role
+  name: label-ns
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: jarvice-label-ns
+  annotations:
+    "helm.sh/hook": pre-upgrade,pre-install
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: jarvice
+spec:
+  template:
+    metadata:
+      name: jarvice-label-ns
+      labels:
+        app: jarvice
+    spec:
+      containers:
+        - name: jarvice-label-ns
+          image: "{{ .Values.jarvice_helm_hook.image }}"
+          imagePullPolicy: "IfNotPresent"
+          command:
+          - kubectl
+          - label
+          - ns
+          - {{ .Release.Namespace }}
+          - app=jarvice
+      restartPolicy: OnFailure
+{{- if (not (empty .Values.jarvice.tolerations)) }}
+      tolerations: {{ .Values.jarvice.tolerations }}
+{{- end }}
+      serviceAccountName: jarvice-label-ns
 {{- if .Values.jarvice_bird.enabled }}
 ---
 apiVersion: batch/v1

--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -225,6 +225,20 @@ resource "helm_release" "jarvice" {
 
     namespace = var.jarvice["namespace"]
     create_namespace = true
+    set {
+        name  = "metadata.labels.app"
+        value = "jarvice"
+    }
+
+    set {
+        name  = "metadata.labels.kubernetes.io/metadata.name"
+        value = "jarvice-system"
+    }
+
+    set {
+        name  = "metadata.labels.kubernetes.io/managed-by"
+        value = "Terraform"
+    }
     reuse_values = false
     reset_values = true
     max_history = 12

--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -232,7 +232,7 @@ resource "helm_release" "jarvice" {
 
     set {
         name  = "metadata.labels.kubernetes.io/metadata.name"
-        value = "jarvice-system"
+        value = var.jarvice["namespace"]
     }
 
     set {

--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -225,20 +225,6 @@ resource "helm_release" "jarvice" {
 
     namespace = var.jarvice["namespace"]
     create_namespace = true
-    set {
-        name  = "metadata.labels.app"
-        value = "jarvice"
-    }
-
-    set {
-        name  = "metadata.labels.kubernetes.io/metadata.name"
-        value = var.jarvice["namespace"]
-    }
-
-    set {
-        name  = "metadata.labels.kubernetes.io/managed-by"
-        value = "Terraform"
-    }
     reuse_values = false
     reset_values = true
     max_history = 12


### PR DESCRIPTION
Adds 3 metadata labels:

- app=jarvice
- kubernetes.io/metadata.name=jarvice-system
- kubernetes.io/managed-by=Terraform

Which should allow trust-manager to create appropriate namespaced root certs.