### PR TITLE
update helm jarvice-pull-system-images script

### DIFF
--- a/scripts/jarvice-pull-system-images
+++ b/scripts/jarvice-pull-system-images
@@ -14,11 +14,10 @@ PUSH_REPOSITORY=$JARVICE_REPOSITORY
 
 DOCKER=docker
 
-JARVICE_IMAGES="jarvice-slurm-scheduler jarvice-dal jarvice-scheduler jarvice-sched-pass jarvice-k8s-scheduler jarvice-pod-scheduler jarvice-api jarvice-mc-portal init initv2 jarvice-appsync jarvice-dockerbuild jarvice-dockerpull jarvice-keycloak jarvice-bird jarvice-bird-portal jarvice-bird-server jarvice-api-v1"
+JARVICE_IMAGES="jarvice-slurm-scheduler jarvice-dal jarvice-scheduler jarvice-sched-pass jarvice-k8s-scheduler jarvice-pod-scheduler jarvice-api jarvice-mc-portal init initv2 jarvice-appsync jarvice-dockerbuild jarvice-dockerpull jarvice-keycloak jarvice-bird jarvice-bird-portal jarvice-bird-server jarvice-api-v1 jarvice-k8s-nested-scheduler"
 JARVICE_PUBLIC_IMAGES="init-kns"
 EXTRA_IMAGES=$(grep -iw image: $values_yaml 2>/dev/null | sed 's/#.*//' | awk '{print $2}' | sort | uniq)
-EXTRA_IMAGES+=$(grep -iw JARVICE_.*_IMAGE: $values_yaml | sed 's/#.*//' | awk '{print $2}' | sed 's/\"//g' | sort | uniq)
-EXTRA_IMAGES+=" quay.io/jetstack/trust-manager:v0.9.2 quay.io/jetstack/cert-manager-package-debian:20210119.0"
+EXTRA_IMAGES+=" quay.io/jetstack/trust-manager:v0.9.2 quay.io/jetstack/cert-manager-package-debian:20210119.0 us-docker.pkg.dev/jarvice/images/unfs3:20231221-1 us-docker.pkg.dev/jarvice/images/alpine:3.18 us-docker.pkg.dev/jarvice/images/kns-gotty:n1.3.0 gcr.io/google-containers/pause:3.2"
 
 function usage {
     cat <<EOF


### PR DESCRIPTION
Update the helm script jarvice-pull-system-images to pull container images that it currently misses:

jarvice-k8s-nested-scheduler, pause, kns-gotty.  Add these to the EXTRA_IMAGES list in the script