### PR TITLE
Fix: JAR-10414 - Set default annotations to an empty map to prevent errors

### DIFF
--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -603,8 +603,12 @@ keycloakx:
     KEYCLOAK_SMTP_PASSWORD:  # smtp password
   ingress:
     enabled: false
-    annotations:
-      cert-manager.io/issuer: # letsencrypt-staging
+    annotations: {}
+      # cert-manager.io/issuer: letsencrypt-staging
+      # cert-manager.io/cluster-issuer: selfsigned
+      ## Resolve HTTP 502 error using ingress-nginx:
+      ## See https://www.ibm.com/support/pages/502-error-ingress-keycloak-response
+      # nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     ingressClassName: traefik
     rules:
     - host: # ingress host

--- a/values.yaml
+++ b/values.yaml
@@ -1595,7 +1595,7 @@ keycloakx:
     # The Service port targeted by the Ingress
     servicePort: http
     # Ingress annotations
-    annotations:
+    annotations: {}
       # cert-manager.io/issuer: letsencrypt-staging
       # cert-manager.io/cluster-issuer: selfsigned
       ## Resolve HTTP 502 error using ingress-nginx:


### PR DESCRIPTION
Set default annotations to an empty map to prevent errors for helm.